### PR TITLE
Add flight-code gen for new projects

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -94,7 +94,7 @@ class Project(db.Model):
     description = db.Column(db.Text, nullable=False)
     dateOfFlight = db.Column(db.Date,  nullable=False)
     
-    flightCode = db.Column(db.String(50), nullable=True ) # nullable for now.
+    flightCode = db.Column(db.String(10), nullable=False)
     pilotID = db.Column(db.Integer, nullable=True) # can be linked to User model later
     lastEdited = db.Column(db.DateTime, default=datetime.now(timezone.utc), onupdate=datetime.now(timezone.utc))
     created_at = db.Column(db.DateTime, default=datetime.now(timezone.utc))
@@ -139,6 +139,20 @@ class Project(db.Model):
             db.session.commit()
         else:
             raise ValueError("Invalid ProjectPurpose ID")
+        
+    # Generate new flightcode based on given project purpose ID
+    @staticmethod
+    def get_new_flightCode(projectPurposeID):
+        purpose = ProjectPurpose.query.get(projectPurposeID)
+        if not purpose:
+            return "UNKNOWN"
+
+        # Count projects of the same purpose
+        count = Project.query.filter_by(projectPurposeID=projectPurposeID).count()
+        purpose_code = purpose.code
+
+        # Generate new flight-code
+        return f"{purpose_code}{count + 1}"
   
 
 class AuditLog(db.Model):

--- a/app/routes_new_project.py
+++ b/app/routes_new_project.py
@@ -84,6 +84,7 @@ def new_project_details():
             projectPurposeID=form.projectPurposeID.data,
             lastEdited=datetime.now(timezone.utc),
             created_at=datetime.now(timezone.utc),
+            flightCode = Project.get_new_flightCode(form.projectPurposeID.data),
             # JSON forms
             viabilityStudy = ViabilityStudyTemplate,
             siteEvaluation = SiteEvaluationTemplate

--- a/app/templates/dashboard/project.html
+++ b/app/templates/dashboard/project.html
@@ -32,7 +32,7 @@
                             </div>
                         </div>
                         <h6>Author: {{project.author.username}}</h6>
-
+                        <h6>Flight Code: {{project.flightCode}}</h6>
                         <h6>Created: {{project.created_at.strftime('%B %d, %Y')}} <span class="text-muted">({{ created_at_humanized }})</span></h6>
                         <h6>Edited: {{project.lastEdited.strftime('%B %d, %Y')}} <span class="text-muted">({{ last_edited_humanized }})</span></h6>
                         <h6>Date of Flight: {{project.dateOfFlight.strftime('%B %d, %Y')}} <span class="text-muted">({{ date_status }})</span></h6>


### PR DESCRIPTION
Added a simple flight-code gen for new projects by using the `project-purpose` code string and concatenating it with the total number of projects for the same purpose.

For example, if 2 practice projects where created, the next new project of the same purpose will get the `P3` flight-code.

The feature builds on the recent addition of `project-purpose`, which was added in PR #27.