### PR TITLE
Ability to add and edit flyer id implemented.

### DIFF
--- a/app/forms/editUserDetails.py
+++ b/app/forms/editUserDetails.py
@@ -8,6 +8,7 @@ from app.utils.validators import validate_password
 class EditUserDetails(FlaskForm):
     display_name = StringField("Display Name", validators=[Optional(), Length(min=3, max=12)])
     email = StringField("Email", validators=[DataRequired(), Email()])
+    flyer_id = StringField("Flyer ID", validators=[Optional(), Length(min=19, max=19, message="Flyer ID must be exactly 19 characters.")])
     submit = SubmitField("Save Changes")
 
 
@@ -24,6 +25,7 @@ class ChangePassword(FlaskForm):
 class EditUserForm(FlaskForm):
     email = StringField('Email', validators=[Email(), Optional()])
     displayname = StringField('Display Name', validators=[Optional()])
+    flyer_id = StringField("Flyer ID", validators=[Optional(), Length(min=19, max=19, message="Flyer ID must be exactly 19 characters.")])
     role_id = SelectField('Role', coerce=int, validators=[Optional()])
 
     password = PasswordField('New Password', validators=[

--- a/app/models.py
+++ b/app/models.py
@@ -22,6 +22,8 @@ class User(db.Model, UserMixin):
     email = db.Column(db.String(120), unique=True, nullable=False)
     password = db.Column(db.String(60), nullable=False)
     displayname = db.Column(db.String(20))
+    flyer_id = db.Column(db.String(20), unique=True, nullable=True)
+
 
     role_id = db.Column(db.Integer, db.ForeignKey('role.id'), nullable=False)
 

--- a/app/routes_admin.py
+++ b/app/routes_admin.py
@@ -55,6 +55,9 @@ def edit_user(user_id):
         if form.displayname.data:
             user.displayname = form.displayname.data
         
+        if form.flyer_id.data:
+            user.flyer_id = form.flyer_id.data
+        
         if form.role_id.data:
             user.role_id = form.role_id.data
 

--- a/app/routes_settings.py
+++ b/app/routes_settings.py
@@ -23,8 +23,9 @@ def edit_profile():
     form = EditUserDetails()
 
     if form.validate_on_submit():
-        # CHange details if user inputs
+        # Change details if user inputs
         current_user.displayname = form.display_name.data
+        current_user.flyer_id = form.flyer_id.data
         current_user.email = form.email.data
 
         
@@ -34,6 +35,7 @@ def edit_profile():
 
     # Fill form with user details
     form.display_name.data = current_user.displayname
+    form.flyer_id.data = current_user.flyer_id
     form.email.data = current_user.email
 
     return render_template("settings/edit_details.html", form=form, title='Edit Details', user=current_user,  footer=False)

--- a/app/templates/admin_panel/edit_user.html
+++ b/app/templates/admin_panel/edit_user.html
@@ -32,8 +32,17 @@
                             <div class="text-danger">{{ form.displayname.errors[0] }}</div>
                         {% endif %}
                     </div>
+
+                    <div class="mb-3">
+                        <label for="flyer_id" class="form-label">Flyer Id</label>
+                        {{ form.flyer_id(class="form-control") }}
+                        {% if form.flyer_id.errors %}
+                            <div class="text-danger">{{ form.flyer_id.errors[0] }}</div>
+                        {% endif %}
+                    </div>
                 </div>
 
+                <hr>
                 <!-- Role Section -->
                 <div class="mb-4">
                     <h4 class="mb-3">Role</h4>
@@ -47,11 +56,13 @@
                     </div>
                 </div>
 
+                <hr>
                 <!-- Password Section -->
                 <div class="mb-4">
-                    <span class="mb-3 fs-4">Change Password 
+                    <h4 class="mb-3">
+                        Change Password 
                         <small class="fs-6 text-muted">(Leave blank to keep current)</small>
-                    </span>
+                    </h4>
 
                     <div class="mb-3">
                         <label for="password" class="form-label">New Password</label>

--- a/app/templates/settings/edit_details.html
+++ b/app/templates/settings/edit_details.html
@@ -36,6 +36,15 @@
                         </div>
 
                         <div class="mb-3">
+                            <label for="flyer_id" class="form-label">Flyer ID</label>
+                            {{ form.flyer_id(class="form-control", 
+                            placeholder="No flyer ID yet", value=current_user.flyer_id if current_user.flyer_id else "") }}
+                            {% for error in form.flyer_id.errors %}
+                                <div class="text-danger">{{ error }}</div>
+                            {% endfor %}
+                        </div>
+
+                        <div class="mb-3">
                             <label for="email" class="form-label">Email</label>
                             {{ form.email(class="form-control") }}
                         </div>

--- a/app/templates/settings/user_profile.html
+++ b/app/templates/settings/user_profile.html
@@ -30,6 +30,10 @@
                     <p><strong><i class="fa-solid fa-user"></i> Username:</strong> {{ user.username }}</p>
                     <p><strong><i class="fa-solid fa-envelope"></i> Email:</strong> {{ user.email }}</p>
                     <p><strong><i class="fa-solid fa-id-card"></i> Role:</strong> {{ user.role.title }}</p>
+                    <p><strong><i class="fa-solid fa-plane-up"></i>Flyer ID
+                        <i class="fa-solid fa-circle-info" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Your assigned Flyer ID (only relevant for pilots)." ></i></strong>
+                        :
+                        {{ user.flyer_id if user.flyer_id else "No Flyer ID" }}</p>
                     <p><strong> User ID:</strong> {{ user.id }}</p>    
                     <p><strong>User Display Name 
                         <i class="fa-solid fa-circle-info" data-bs-toggle="tooltip" data-bs-placement="bottom" title="A display name will be shown instead of username" ></i></strong>


### PR DESCRIPTION
Added flyer ID to user model, nullable=true as not all users need one.
Exactly 19 characters required in forms as example IDs have that many.  E.g. GBR-RP-LDP6DZ4QDVWV

I decided instead of adding a new section to settings to add the ability to add flyer ID on Profile Page. I believe as a user it would be useful to have all of my user details in the one place. 

Added ability to edit flyer ID in Admin Panel.
Minor changes made to user interface on Admin panel - edit user details page.