### PR TITLE
Feature/project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,6 @@ cython_debug/
 *.iml
 *.ipr
 *.iws
+
+# Server uploads
+/uploads

--- a/app/models.py
+++ b/app/models.py
@@ -217,3 +217,21 @@ project_access = db.Table(
     db.Column('project_id', db.Integer, db.ForeignKey('project.id'), primary_key=True),
     db.Column('user_id', db.Integer, db.ForeignKey('user.id'), primary_key=True),
 )
+
+class ProjectFile(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    original_filename = db.Column(db.String(255), nullable=False)  # user-friendly name
+    filename = db.Column(db.String(255), nullable=False)  # Unique filename
+    filepath = db.Column(db.String(255), nullable=False)
+    size = db.Column(db.Integer, nullable=False)
+    uploaded_at = db.Column(db.DateTime, default=datetime.now(timezone.utc))
+    project_id = db.Column(db.Integer, db.ForeignKey('project.id'), nullable=False)
+    project = db.relationship('Project', backref=db.backref('files', lazy=True))
+
+    def human_readable_size(self):
+        size = self.size
+        for unit in ['B', 'KB', 'MB', 'GB', 'TB']:
+            if size < 1024.0:
+                return f"{size:.1f} {unit}"
+            size /= 1024.0
+        return f"{size:.1f} TB"

--- a/app/routes_new_project.py
+++ b/app/routes_new_project.py
@@ -322,7 +322,10 @@ def project_files(project_id):
         flash("You are not authorised to edit this project.", "danger")
         return redirect(url_for('dashboard'))
 
-    return render_template('/dashboard/project_files.html', project=project)
+    return render_template('/dashboard/project_files.html', project=project, footer=False,
+        max_file_size=MAX_FILE_SIZE, 
+        allowed_extensions=ALLOWED_EXTENSIONS, 
+        max_files=MAX_FILES_PER_PROJECT)
 
 
 @app.route('/project/<int:project_id>/files/upload', methods=['POST'])

--- a/app/routes_new_project.py
+++ b/app/routes_new_project.py
@@ -1,12 +1,15 @@
 from copy import deepcopy
 from datetime import datetime, timezone
+import uuid
+from werkzeug.utils import secure_filename
+import os
 from app import app, db
-from flask import flash, redirect, render_template, session, url_for, request, jsonify
+from flask import flash, redirect, render_template, send_from_directory, session, url_for, request, jsonify
 from flask_login import current_user, login_required
 
 from app.AuditLogger import AuditLogger
 from app.forms.createProject import EditProject, ProjectLocation, ProjectType, ProjectDetails, ProjectToggles
-from app.models import Project, User
+from app.models import Project, ProjectFile, User
 
 from app.forms.jsons.viabilityStudyTemplate import ViabilityStudyTemplate
 from app.forms.jsons.siteEvaluationTemplate import SiteEvaluationTemplate
@@ -16,6 +19,11 @@ from app.forms.jsons.loadingListEquipmentTemplate import LoadingListEquipmentTem
 from app.forms.jsons.postFlightTemplate import PostFlightTemplate
 from app.forms.jsons.loadingListCrewListTemplate import LoadingListCrewListTemplate
 from app.forms.jsons.loadingListGroundEquipmentTemplate import LoadingListGroundEquipmentTemplate
+
+UPLOAD_FOLDER = 'uploads/'
+MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
+ALLOWED_EXTENSIONS = {'pdf', 'doc', 'docx', 'xls', 'xlsx', 'csv', 'ppt', 'pptx', 'txt', 'png', 'jpg', 'jpeg'}
+MAX_FILES_PER_PROJECT = 10
 
 # Step 1: Get location of the project
 @app.route("/create_project/location", methods=['GET','POST'])
@@ -296,3 +304,131 @@ def search_users():
     query = request.args.get('query')
     users = User.query.filter(User.username.ilike(f"%{query}%")).all()
     return jsonify([{'id': user.id, 'username': user.username} for user in users])
+
+
+
+############################ PROJECT FILES ############################
+# Helper function to check allowed file types
+def allowed_file(filename):
+    return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+
+@app.route('/project/<int:project_id>/files', methods=['GET'])
+@login_required
+def project_files(project_id):
+    project = Project.query.get_or_404(project_id)
+
+    # Can access?
+    if not project.can_access():
+        flash("You are not authorised to edit this project.", "danger")
+        return redirect(url_for('dashboard'))
+
+    return render_template('/dashboard/project_files.html', project=project)
+
+
+@app.route('/project/<int:project_id>/files/upload', methods=['POST'])
+@login_required
+def upload_file(project_id):
+    project = Project.query.get_or_404(project_id)
+
+    # Can access
+    if not project.can_access():
+        flash("You are not authorised to edit this project.", "danger")
+        return redirect(url_for('dashboard'))
+    
+    # Max number of files per project
+    if len(project.files) >= MAX_FILES_PER_PROJECT:
+        flash(f"Maximum of {MAX_FILES_PER_PROJECT} files allowed.", "danger")
+        return redirect(url_for('project_files', project_id=project_id))
+
+    file = request.files.get('file')
+
+    # No file
+    if not file or file.filename == '':
+        flash("No file selected!", "danger")
+        return redirect(url_for('project_files', project_id=project_id))
+
+    # Allowed file
+    if not allowed_file(file.filename):
+        flash(f"Invalid file type! Allowed types: {', '.join(ALLOWED_EXTENSIONS)}", "danger")
+        return redirect(url_for('project_files', project_id=project_id))
+
+    original_filename = secure_filename(file.filename)
+
+    # Check if file with the same name already exists
+    existing_file = ProjectFile.query.filter_by(project_id=project.id, original_filename=original_filename).first()
+
+    if existing_file:
+        # Delete old file before replacing
+        if os.path.exists(existing_file.filepath):
+            os.remove(existing_file.filepath)
+
+        # Keep same database entry but update filename and path
+        unique_filename = f"{project_id}_{uuid.uuid4().hex}_{original_filename}"
+        filepath = os.path.join(UPLOAD_FOLDER, unique_filename)
+        
+        # Save and update record
+        file.save(filepath)
+
+        existing_file.filename = unique_filename
+        existing_file.filepath = filepath
+        existing_file.size = os.path.getsize(filepath)
+        existing_file.uploaded_at = datetime.utcnow()
+        db.session.commit()
+
+        flash("File replaced successfully!", "success")
+    else:
+        # New file upload (<ProjectID>_<UUID>_<filename>)
+        unique_filename = f"{project_id}_{uuid.uuid4().hex}_{original_filename}"
+        filepath = os.path.join(UPLOAD_FOLDER, unique_filename)
+        
+        # Ensure folder exists and save
+        os.makedirs(UPLOAD_FOLDER, exist_ok=True)  
+        file.save(filepath)
+
+        new_file = ProjectFile(
+            filename=unique_filename,
+            original_filename=original_filename,
+            filepath=filepath,
+            size=os.path.getsize(filepath),
+            project_id=project.id
+        )
+        db.session.add(new_file)
+        db.session.commit()
+
+        flash("File uploaded successfully!", "success")
+
+    return redirect(url_for('project_files', project_id=project_id))
+
+
+@app.route('/project/<int:project_id>/files/<int:file_id>/download')
+@login_required
+def download_file(project_id, file_id):
+    file = ProjectFile.query.get_or_404(file_id)
+
+    # File belongs to project the user has access
+    if not file.project.can_access():
+        flash("You are not authorised to download this file.", "danger")
+        return redirect(url_for('dashboard'))
+
+    directory = os.path.abspath(UPLOAD_FOLDER)
+    return send_from_directory(directory, file.filename, as_attachment=True, download_name=file.original_filename)
+
+
+@app.route('/project/<int:project_id>/files/<int:file_id>/delete', methods=['POST'])
+@login_required
+def delete_file(project_id, file_id):
+    file = ProjectFile.query.get_or_404(file_id)
+
+     # File belongs to project the user has access
+    if not file.project.can_access():
+        flash("You are not authorised to delete this file.", "danger")
+        return redirect(url_for('dashboard'))
+
+    if os.path.exists(file.filepath):
+        os.remove(file.filepath)
+
+    db.session.delete(file)
+    db.session.commit()
+    
+    flash("File deleted successfully!", "success")
+    return redirect(url_for('project_files', project_id=project_id))

--- a/app/templates/dashboard/project.html
+++ b/app/templates/dashboard/project.html
@@ -102,6 +102,11 @@
                                 <div class="col-md-4 mb-3 text-center">
                                     <a href="{{ url_for('personal',project_id=project.id) }}" class="btn btn-secondary w-100"><i class="fas fa-check-circle"></i> Personal Checklist</a>
                                 </div>
+
+                                <!--  -->
+                                <div class="col-md-4 mb-3 text-center">
+                                    <a href="{{ url_for('project_files', project_id=project.id) }}" class="btn btn-primary w-100"> <i class="fas fa-folder-open"></i> Project Files</a>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/app/templates/dashboard/project_files.html
+++ b/app/templates/dashboard/project_files.html
@@ -1,0 +1,45 @@
+{% extends "dashboard/dashboard_base.html" %}
+
+{% block main_content %}
+<div class="card shadow-sm">
+    <div class="card-body">
+        <h2>Project Files</h2>
+
+        {% include 'shared/flash-message.html' %}
+
+        <form action="{{ url_for('upload_file', project_id=project.id) }}" method="post" enctype="multipart/form-data"
+            class="mb-4">
+            <input type="file" name="file" class="form-control mb-2" required>
+            <button type="submit" class="btn btn-primary">Upload</button>
+        </form>
+
+        <h4>Uploaded Files</h4>
+        <ul class="list-group">
+            {% for file in project.files %}
+            <li class="list-group-item d-flex justify-content-between align-items-center">
+                <div>
+                    <a href="{{ url_for('download_file', project_id=project.id, file_id=file.id) }}">
+                        {{ file.original_filename }}
+                    </a>
+                    <br>
+                    <small class="text-muted">
+                        Uploaded: {{ file.uploaded_at.strftime('%d %b, %Y - %H:%M') }} | 
+                        Size: {{ file.human_readable_size() }}
+                    </small>
+                </div>
+                <form action="{{ url_for('delete_file', project_id=project.id, file_id=file.id) }}" method="post"
+                    class="d-inline">
+                    <button type="submit" class="btn btn-danger btn-sm">Delete</button>
+                </form>
+            </li>
+            {% else %}
+            <p>No files uploaded yet.</p>
+            {% endfor %}
+        </ul>
+
+        <a href="{{ url_for('project', project_id=project.id) }}" class="btn btn-primary my-3">
+            Back to Project
+        </a>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/dashboard/project_files.html
+++ b/app/templates/dashboard/project_files.html
@@ -8,13 +8,20 @@
         {% include 'shared/flash-message.html' %}
 
         <!-- File Upload Information -->
-        <div class="alert alert-info">
-            <h5 class="mb-1"><i class="fas fa-info-circle"></i> Upload Guidelines</h5>
-            <ul class="mb-0">
-                <li><strong>Max Files:</strong> {{ max_files }} per project</li>
-                <li><strong>Allowed Types:</strong> {{ allowed_extensions | join(', ') }}</li>
-                <li><strong>Max File Size:</strong> {{ (max_file_size / (1024 * 1024)) | int }}MB per file</li>
-            </ul>
+        <div class="mb-3">
+            <button class="btn btn-outline-danger" type="button" data-bs-toggle="collapse" data-bs-target="#uploadGuidelines"
+                aria-expanded="false" aria-controls="uploadGuidelines">
+                <i class="fas fa-info-circle"></i> Upload Guidelines
+            </button>
+            <div class="collapse mt-2" id="uploadGuidelines">
+                <div class="alert alert-info">
+                    <ul class="mb-0">
+                        <li><strong>Max Files:</strong> {{ max_files }} per project</li>
+                        <li><strong>Allowed Types:</strong> {{ allowed_extensions | join(', ') }}</li>
+                        <li><strong>Max File Size:</strong> {{ (max_file_size / (1024 * 1024)) | int }}MB per file</li>
+                    </ul>
+                </div>
+            </div>
         </div>
 
         {% if project.files|length < max_files %}

--- a/app/templates/dashboard/project_files.html
+++ b/app/templates/dashboard/project_files.html
@@ -7,11 +7,28 @@
 
         {% include 'shared/flash-message.html' %}
 
-        <form action="{{ url_for('upload_file', project_id=project.id) }}" method="post" enctype="multipart/form-data"
-            class="mb-4">
-            <input type="file" name="file" class="form-control mb-2" required>
-            <button type="submit" class="btn btn-primary">Upload</button>
-        </form>
+        <!-- File Upload Information -->
+        <div class="alert alert-info">
+            <h5 class="mb-1"><i class="fas fa-info-circle"></i> Upload Guidelines</h5>
+            <ul class="mb-0">
+                <li><strong>Max Files:</strong> {{ max_files }} per project</li>
+                <li><strong>Allowed Types:</strong> {{ allowed_extensions | join(', ') }}</li>
+                <li><strong>Max File Size:</strong> {{ (max_file_size / (1024 * 1024)) | int }}MB per file</li>
+            </ul>
+        </div>
+
+        {% if project.files|length < max_files %}
+            <form action="{{ url_for('upload_file', project_id=project.id) }}" method="post" enctype="multipart/form-data"
+                class="mb-4">
+                <input type="file" name="file" class="form-control mb-2" required>
+                <button type="submit" class="btn btn-primary">Upload</button>
+            </form>
+        {% else %}
+            <div class="alert alert-warning">
+                <i class="fas fa-exclamation-triangle"></i> You have reached the maximum file limit ({{ max_files }} files). 
+                Please remove existing files if you need to upload new ones.
+            </div>
+        {% endif %}
 
         <h4>Uploaded Files</h4>
         <ul class="list-group">


### PR DESCRIPTION
This PR adds the Project File Upload feature, allowing users to upload, manage, and download project files. 

### Features
- "Project Files" Panel for managing files.
- Supports `.pdf`, `.doc`, `.docx`, `.xls`, `.xlsx`, `.txt`, `.rtf`, `.odt`, and a few others (max 10MB).
- File Management: Download, replace (same name), and delete files.
- Max 10 Files per Project with error handling.
- Displays file metadata: name, size (human-readable), and upload date.

> [!NOTE]
>  A new DB model `ProjectFile` was added, and the `.gitignore` was modified to ensure it skips any uploaded files.